### PR TITLE
Reset vertical margin to 0

### DIFF
--- a/src/components/Menus/TopMenu/DarkModeToggle/DarkModeToggle.sass
+++ b/src/components/Menus/TopMenu/DarkModeToggle/DarkModeToggle.sass
@@ -8,7 +8,7 @@
     display: inline-block
     width: 32px
     height: 16px
-    margin-right: 10px
+    margin: 0 10px
 
   &-switch input
     opacity: 0


### PR DESCRIPTION
There was a bootstrap style that adds margin-bottom to labels. Therefore, I have to reset the vertical margin for this specific label